### PR TITLE
Convert `flatMap` → `compactMap` for Swift 4.1+ users

### DIFF
--- a/Sources/JSONExtractionExtensions.swift
+++ b/Sources/JSONExtractionExtensions.swift
@@ -356,7 +356,11 @@ extension Dictionary
     {
         let extractedArray: [A] = try requiredArrayWithTypecast(key)
 
+        #if swift(>=4.1)
+        return extractedArray.compactMap { transform($0) }
+        #else
         return extractedArray.flatMap { transform($0) }
+        #endif
     }
 
     /**
@@ -413,8 +417,11 @@ extension Dictionary
         -> [T]?
     {
         guard let array: [A] = value(key) else { return nil }
-
+        #if swift(>=4.1)
+        return array.compactMap { transform($0) }
+        #else
         return array.flatMap { transform($0) }
+        #endif
     }
 
     /**

--- a/Sources/JSONExtractionExtensions.swift
+++ b/Sources/JSONExtractionExtensions.swift
@@ -356,11 +356,7 @@ extension Dictionary
     {
         let extractedArray: [A] = try requiredArrayWithTypecast(key)
 
-        #if swift(>=4.1)
         return extractedArray.compactMap { transform($0) }
-        #else
-        return extractedArray.flatMap { transform($0) }
-        #endif
     }
 
     /**
@@ -417,11 +413,8 @@ extension Dictionary
         -> [T]?
     {
         guard let array: [A] = value(key) else { return nil }
-        #if swift(>=4.1)
+        
         return array.compactMap { transform($0) }
-        #else
-        return array.flatMap { transform($0) }
-        #endif
     }
 
     /**


### PR DESCRIPTION
Add compactMap compatibility for Swift 4.1 / Xcode 9.3 users  